### PR TITLE
Pass all the inputs for category repositories

### DIFF
--- a/.changeset/social-walls-behave.md
+++ b/.changeset/social-walls-behave.md
@@ -1,0 +1,5 @@
+---
+"@saleor/configurator": patch
+---
+
+Fixed category slug being skipped during creation

--- a/src/modules/category/category-service.ts
+++ b/src/modules/category/category-service.ts
@@ -21,9 +21,7 @@ export class CategoryService {
     });
 
     const category = await this.repository.createCategory(
-      {
-        name: input.name,
-      },
+      input,
       parentId
     );
 

--- a/src/modules/category/repository.ts
+++ b/src/modules/category/repository.ts
@@ -9,11 +9,13 @@ const createCategoryMutation = graphql(`
       category {
         id
         name
+        slug
         children(first: 100) {
           edges {
             node {
               id
               name
+              slug
             }
           }
         }
@@ -35,6 +37,7 @@ const getCategoryByNameQuery = graphql(`
         node {
           id
           name
+          slug
           children(first: 100) {
             edges {
               node {
@@ -92,9 +95,7 @@ export class CategoryRepository implements CategoryOperations {
     });
 
     const result = await this.client.mutation(createCategoryMutation, {
-      input: {
-        name: input.name,
-      },
+      input,
       parent: parentId,
     });
 


### PR DESCRIPTION
Despite slug being specified in the config, it was ignored during category creation.
Modified repository code to pass all fields for the mutations.