### PR TITLE
ci: set NODE_AUTH_TOKEN for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,3 +54,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- export NODE_AUTH_TOKEN in the release workflow so setup-node writes the correct token
- npm publish no longer uses the placeholder token that breaks authentication

## Testing
- not run (workflow change only)
