### PR TITLE
fix: inject dependencies into MenuService to resolve category references

### DIFF
--- a/.changeset/modern-places-change.md
+++ b/.changeset/modern-places-change.md
@@ -1,0 +1,9 @@
+---
+"@saleor/configurator": patch
+---
+
+Fix menu items not linking to categories when created via configurator.
+
+Menu items specified with category slugs (e.g., `category: "photobooks"`) now properly resolve to category IDs and link correctly in Saleor. Previously, the MenuService was missing required dependencies (CategoryService, CollectionService, ModelService), causing category resolution to be skipped and resulting in `category: null` in the API response.
+
+This fix ensures menu structures work correctly in storefronts by injecting the necessary services during MenuService initialization.

--- a/src/core/service-container.ts
+++ b/src/core/service-container.ts
@@ -93,6 +93,15 @@ export class ServiceComposer {
     });
     const pageTypeService = new PageTypeService(repositories.pageType, attributeService);
 
+    // Create services that MenuService depends on
+    const categoryService = new CategoryService(repositories.category);
+    const modelService = new ModelService(repositories.model, pageTypeService, attributeService);
+    const collectionService = new CollectionService(
+      repositories.collection,
+      productService,
+      channelService
+    );
+
     // Create service container first (without diffService to avoid circular dependency)
     const services = {
       attribute: attributeService,
@@ -102,7 +111,7 @@ export class ServiceComposer {
       shop: new ShopService(repositories.shop),
       configuration: configurationService,
       configStorage,
-      category: new CategoryService(repositories.category),
+      category: categoryService,
       product: productService,
       warehouse: new WarehouseService(repositories.warehouse),
       shippingZone: new ShippingZoneService(
@@ -113,9 +122,9 @@ export class ServiceComposer {
       tax: new TaxService({
         repository: repositories.tax,
       }),
-      collection: new CollectionService(repositories.collection, productService, channelService),
-      menu: new MenuService(repositories.menu),
-      model: new ModelService(repositories.model, pageTypeService, attributeService),
+      collection: collectionService,
+      menu: new MenuService(repositories.menu, categoryService, collectionService, modelService),
+      model: modelService,
     } as Omit<ServiceContainer, "diffService">;
 
     // Create diff service with the services container


### PR DESCRIPTION
## Problem

Menu items created via configurator were not linking to categories, resulting in `category: null` in the API response. This broke menu structures in storefronts.

**Linear Issue**: CXE-1190

## Root Cause

`MenuService` was missing its optional dependencies (`CategoryService`, `CollectionService`, `ModelService`) during initialization in the service container. Without these services, the category resolution logic was silently skipped.

## Solution

- Created service instances (`categoryService`, `collectionService`, `modelService`) before the services object to avoid circular dependencies
- Injected these dependencies into `MenuService` constructor following the same pattern used by `CollectionService`
- Added integration tests verifying:
  - Category slugs are properly resolved to IDs when services are available
  - Graceful handling when services are not injected

## Changes

**Modified Files:**
- `src/core/service-container.ts` - Fixed dependency injection
- `src/modules/menu/menu-service.test.ts` - Added integration tests
- `.changeset/modern-places-change.md` - Added changelog entry

## Testing

- ✅ All existing menu service tests pass (19/19)
- ✅ New integration tests verify category resolution
- ✅ Biome formatting applied
- ✅ No regressions in core module tests

## Impact

Menu items with category references (e.g., `category: "photobooks"`) now properly resolve to category IDs and link correctly in Saleor, enabling menu structures to work as expected in storefronts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)