### PR TITLE
Add Saleor 3.23 compatibility

### DIFF
--- a/.changeset/final-1x-saleor-323-hotfix.md
+++ b/.changeset/final-1x-saleor-323-hotfix.md
@@ -1,0 +1,7 @@
+---
+"@saleor/configurator": patch
+---
+
+Restore compatibility with Saleor 3.23 by ignoring legacy digital shop settings removed from Saleor. Configurator 1.x still validates existing config files that contain `automaticFulfillmentDigitalProducts`, `defaultDigitalMaxDownloads`, and `defaultDigitalUrlValidDays`, but it no longer queries or sends those fields to Saleor.
+
+This is the final 1.x compatibility update. Configurator 1.x supports Saleor versions only up to 3.23; Saleor 3.24+ and future minors require Configurator 2.x.

--- a/src/commands/deploy.integration.test.ts
+++ b/src/commands/deploy.integration.test.ts
@@ -9,6 +9,7 @@ import {
 import type { TempDirectory } from "../test-helpers/filesystem";
 import { createTempDirectory } from "../test-helpers/filesystem";
 import { createFetchMock } from "../test-helpers/graphql-mocks";
+import { LEGACY_DIGITAL_SHOP_SETTINGS_WARNING } from "../modules/shop/legacy-digital-settings";
 import { deployHandler } from "./deploy";
 
 const TEST_URL = "https://test.saleor.cloud/graphql/";
@@ -95,6 +96,51 @@ describe("Deploy Command - Integration Tests", () => {
         authorization: `Bearer ${TEST_TOKEN}`,
         "content-type": "application/json",
       });
+    });
+
+    it("should warn and strip legacy digital shop settings before deploy mutation", async () => {
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const configPath = createConfigFile()
+        .withShop({
+          defaultMailSenderName: "Updated Shop Name",
+          automaticFulfillmentDigitalProducts: true,
+          defaultDigitalMaxDownloads: 5,
+          defaultDigitalUrlValidDays: 14,
+        })
+        .saveToFile(tempDir);
+
+      await expect(
+        deployHandler({
+          url: TEST_URL,
+          token: TEST_TOKEN,
+          config: configPath,
+          quiet: false,
+          verbose: false,
+          json: false,
+          plan: false,
+          failOnDelete: false,
+          skipMedia: false,
+          text: true,
+        })
+      ).rejects.toThrow("process.exit(0)");
+
+      expect(
+        consoleSpy.mock.calls.some(([message]) =>
+          String(message).includes(LEGACY_DIGITAL_SHOP_SETTINGS_WARNING)
+        )
+      ).toBe(true);
+
+      const shopUpdateCalls = (fetchSpy?.mock.calls as FetchMockCall[]).filter((call) => {
+        const body = call[1]?.body?.toString();
+        return body?.includes("shopSettingsUpdate");
+      });
+      expect(shopUpdateCalls.length).toBeGreaterThan(0);
+
+      const requestBody = JSON.parse(shopUpdateCalls[0]?.[1]?.body?.toString() ?? "{}");
+      expect(requestBody.variables.input).toEqual({
+        defaultMailSenderName: "Updated Shop Name",
+      });
+      expect(requestBody.query).not.toContain("automaticFulfillmentDigitalProducts");
     });
 
     it("should handle no changes scenario gracefully", async () => {

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -38,6 +38,10 @@ import { globalLogCollector } from "../lib/json-log-collector";
 import { logger } from "../lib/logger";
 import { COMMAND_NAME } from "../meta";
 import { AttributeCache } from "../modules/attribute/attribute-cache";
+import {
+  hasLegacyDigitalShopSettings,
+  LEGACY_DIGITAL_SHOP_SETTINGS_WARNING,
+} from "../modules/shop/legacy-digital-settings";
 
 export const deployCommandSchema = baseCommandArgsSchema.extend({
   reportPath: z
@@ -352,6 +356,24 @@ class DeployCommandHandler implements CommandHandler<DeployCommandArgs, void> {
     }
   }
 
+  private async warnAboutLegacyDigitalShopSettings(
+    configurator: ReturnType<typeof createConfigurator>,
+    useJson: boolean
+  ): Promise<void> {
+    const cfg = await configurator.services.configStorage.load();
+
+    if (!cfg.shop || !hasLegacyDigitalShopSettings(cfg.shop)) {
+      return;
+    }
+
+    if (useJson) {
+      logger.warn(LEGACY_DIGITAL_SHOP_SETTINGS_WARNING);
+      return;
+    }
+
+    this.console.warn(LEGACY_DIGITAL_SHOP_SETTINGS_WARNING);
+  }
+
   private async analyzeDifferences(
     args: DeployCommandArgs,
     configurator: ReturnType<typeof createConfigurator>
@@ -476,6 +498,7 @@ class DeployCommandHandler implements CommandHandler<DeployCommandArgs, void> {
 
     try {
       await this.validateLocalConfiguration(args, configurator);
+      await this.warnAboutLegacyDigitalShopSettings(configurator, useJson);
 
       if (!useJson) {
         this.console.muted("⏳ Analyzing configuration differences...");

--- a/src/core/diff/comparators/shop-comparator.ts
+++ b/src/core/diff/comparators/shop-comparator.ts
@@ -14,8 +14,6 @@ interface ShopSettings {
   readonly trackInventoryByDefault?: boolean;
   readonly reserveStockDurationAnonymousUser?: number;
   readonly reserveStockDurationAuthenticatedUser?: number;
-  readonly defaultDigitalMaxDownloads?: number;
-  readonly defaultDigitalUrlValidDays?: number;
   readonly defaultWeightUnit?: string;
   readonly allowLoginWithoutConfirmation?: boolean;
 }
@@ -32,8 +30,6 @@ const SHOP_SETTINGS_FIELDS: ReadonlyArray<keyof ShopSettings> = [
   "trackInventoryByDefault",
   "reserveStockDurationAnonymousUser",
   "reserveStockDurationAuthenticatedUser",
-  "defaultDigitalMaxDownloads",
-  "defaultDigitalUrlValidDays",
   "defaultWeightUnit",
   "allowLoginWithoutConfirmation",
 ] as const;

--- a/src/modules/config/config-service.test.ts
+++ b/src/modules/config/config-service.test.ts
@@ -37,8 +37,6 @@ const mockRawShopData: RawSaleorConfig["shop"] = {
   trackInventoryByDefault: false,
   reserveStockDurationAnonymousUser: 60,
   reserveStockDurationAuthenticatedUser: 60,
-  defaultDigitalMaxDownloads: 10,
-  defaultDigitalUrlValidDays: 10,
   defaultWeightUnit: "KG" as const,
   allowLoginWithoutConfirmation: false,
 };
@@ -52,8 +50,6 @@ const mockMappedShopData: SaleorConfig["shop"] = {
   trackInventoryByDefault: false,
   reserveStockDurationAnonymousUser: 60,
   reserveStockDurationAuthenticatedUser: 60,
-  defaultDigitalMaxDownloads: 10,
-  defaultDigitalUrlValidDays: 10,
   defaultWeightUnit: "KG" as const,
   allowLoginWithoutConfirmation: false,
 };

--- a/src/modules/config/config-service.ts
+++ b/src/modules/config/config-service.ts
@@ -397,8 +397,6 @@ export class ConfigurationService {
       trackInventoryByDefault: settings.trackInventoryByDefault,
       reserveStockDurationAnonymousUser: settings.reserveStockDurationAnonymousUser,
       reserveStockDurationAuthenticatedUser: settings.reserveStockDurationAuthenticatedUser,
-      defaultDigitalMaxDownloads: settings.defaultDigitalMaxDownloads,
-      defaultDigitalUrlValidDays: settings.defaultDigitalUrlValidDays,
       defaultWeightUnit: settings.defaultWeightUnit,
       allowLoginWithoutConfirmation: settings.allowLoginWithoutConfirmation,
     });

--- a/src/modules/config/repository.test.ts
+++ b/src/modules/config/repository.test.ts
@@ -70,7 +70,69 @@ function makeEmptyChoices() {
   };
 }
 
+type FieldSelection = {
+  kind: string;
+  name?: { value: string };
+  selectionSet?: { selections: FieldSelection[] };
+};
+
+function collectFieldNames(selection: FieldSelection | undefined, fieldNames = new Set<string>()) {
+  if (!selection) {
+    return fieldNames;
+  }
+
+  if (selection.kind === "Field" && selection.name?.value) {
+    fieldNames.add(selection.name.value);
+  }
+
+  for (const child of selection.selectionSet?.selections ?? []) {
+    collectFieldNames(child, fieldNames);
+  }
+
+  return fieldNames;
+}
+
 describe("ConfigurationRepository", () => {
+  it("should not query Saleor 3.23 removed digital shop fields", async () => {
+    const capturedDocuments: TypedDocumentNode[] = [];
+
+    const mockClient: Client = {
+      query: async (document: TypedDocumentNode) => {
+        capturedDocuments.push(document);
+
+        const operation = document.definitions.find(
+          (definition: { kind: string }) => definition.kind === "OperationDefinition"
+        ) as { name?: { value: string } } | undefined;
+
+        if (operation?.name?.value === "GetProductsPage") {
+          return { data: { products: makeEmptyPage() } };
+        }
+
+        if (operation?.name?.value === "GetAttributesPage") {
+          return { data: { attributes: makeEmptyPage() } };
+        }
+
+        return { data: makeEmptyConfigData() };
+      },
+      mutation: async () => {
+        throw new Error("Not implemented");
+      },
+      subscribe: () => {
+        throw new Error("Not implemented");
+      },
+    } as unknown as Client;
+
+    const repository = new ConfigurationRepository(mockClient);
+    await repository.fetchConfig();
+
+    const getConfigDocument = capturedDocuments[0];
+    const operation = getConfigDocument.definitions[0] as FieldSelection;
+    const fieldNames = collectFieldNames(operation);
+
+    expect(fieldNames.has("defaultDigitalMaxDownloads")).toBe(false);
+    expect(fieldNames.has("defaultDigitalUrlValidDays")).toBe(false);
+  });
+
   it("should keep product channel listings outside variant scope in pagination query", async () => {
     const capturedDocuments: TypedDocumentNode[] = [];
 
@@ -111,11 +173,6 @@ describe("ConfigurationRepository", () => {
     );
     expect(productsField).toBeDefined();
 
-    type FieldSelection = {
-      kind: string;
-      name?: { value: string };
-      selectionSet?: { selections: FieldSelection[] };
-    };
     const edgesField = (productsField as FieldSelection)?.selectionSet?.selections.find(
       (selection) => selection.kind === "Field" && selection.name?.value === "edges"
     );

--- a/src/modules/config/repository.ts
+++ b/src/modules/config/repository.ts
@@ -15,8 +15,6 @@ const getConfigQuery = graphql(`
       trackInventoryByDefault
       reserveStockDurationAnonymousUser
       reserveStockDurationAuthenticatedUser
-      defaultDigitalMaxDownloads
-      defaultDigitalUrlValidDays
       defaultWeightUnit
       allowLoginWithoutConfirmation
     }

--- a/src/modules/config/schema/schema.test.ts
+++ b/src/modules/config/schema/schema.test.ts
@@ -173,6 +173,24 @@ describe("Schema Union Types", () => {
         trackInventoryByDefault: false,
       });
     });
+
+    it("should continue validating legacy digital shop settings", () => {
+      const updateInput = {
+        shop: {
+          automaticFulfillmentDigitalProducts: true,
+          defaultDigitalMaxDownloads: 5,
+          defaultDigitalUrlValidDays: 14,
+        },
+      };
+
+      const result = configSchema.parse(updateInput);
+
+      expect(result.shop).toEqual({
+        automaticFulfillmentDigitalProducts: true,
+        defaultDigitalMaxDownloads: 5,
+        defaultDigitalUrlValidDays: 14,
+      });
+    });
   });
 
   describe("PageType Schema", () => {

--- a/src/modules/shop/legacy-digital-settings.ts
+++ b/src/modules/shop/legacy-digital-settings.ts
@@ -1,0 +1,28 @@
+export const LEGACY_DIGITAL_SHOP_SETTINGS_WARNING =
+  "Legacy digital shop settings were removed from Saleor 3.23 and are ignored by Configurator 1.x.";
+
+export const LEGACY_DIGITAL_SHOP_SETTINGS = [
+  "automaticFulfillmentDigitalProducts",
+  "defaultDigitalMaxDownloads",
+  "defaultDigitalUrlValidDays",
+] as const;
+
+type LegacyDigitalShopSetting = (typeof LEGACY_DIGITAL_SHOP_SETTINGS)[number];
+
+export function hasLegacyDigitalShopSettings(input: Record<string, unknown>): boolean {
+  return LEGACY_DIGITAL_SHOP_SETTINGS.some((field) =>
+    Object.prototype.hasOwnProperty.call(input, field)
+  );
+}
+
+export function stripLegacyDigitalShopSettings<T extends Record<string, unknown>>(
+  input: T
+): Omit<T, LegacyDigitalShopSetting> {
+  const sanitized = { ...input };
+
+  for (const field of LEGACY_DIGITAL_SHOP_SETTINGS) {
+    delete sanitized[field];
+  }
+
+  return sanitized;
+}

--- a/src/modules/shop/repository.ts
+++ b/src/modules/shop/repository.ts
@@ -12,7 +12,6 @@ const updateShopSettingsMutation = graphql(`
         defaultWeightUnit
         fulfillmentAutoApprove
         fulfillmentAllowUnpaid
-        automaticFulfillmentDigitalProducts
       }
       errors {
         field

--- a/src/modules/shop/shop-service.test.ts
+++ b/src/modules/shop/shop-service.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+import { ShopService } from "./shop-service";
+
+describe("ShopService", () => {
+  it("should strip legacy digital settings before updating shop settings", async () => {
+    const repository = {
+      updateShopSettings: vi.fn().mockResolvedValue(undefined),
+    };
+    const service = new ShopService(repository);
+
+    await service.updateSettings({
+      defaultMailSenderName: "Test Shop",
+      automaticFulfillmentDigitalProducts: true,
+      defaultDigitalMaxDownloads: 5,
+      defaultDigitalUrlValidDays: 14,
+    });
+
+    expect(repository.updateShopSettings).toHaveBeenCalledWith({
+      defaultMailSenderName: "Test Shop",
+    });
+  });
+
+  it("should skip the update when only legacy digital settings are provided", async () => {
+    const repository = {
+      updateShopSettings: vi.fn().mockResolvedValue(undefined),
+    };
+    const service = new ShopService(repository);
+
+    await service.updateSettings({
+      automaticFulfillmentDigitalProducts: true,
+      defaultDigitalMaxDownloads: 5,
+      defaultDigitalUrlValidDays: 14,
+    });
+
+    expect(repository.updateShopSettings).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/shop/shop-service.ts
+++ b/src/modules/shop/shop-service.ts
@@ -2,6 +2,7 @@ import { logger } from "../../lib/logger";
 import { ServiceErrorWrapper } from "../../lib/utils/error-wrapper";
 import type { ShopInput } from "../config/schema/schema";
 import { ShopSettingsUpdateError } from "./errors";
+import { stripLegacyDigitalShopSettings } from "./legacy-digital-settings";
 import type { ShopOperations } from "./repository";
 
 export class ShopService {
@@ -25,8 +26,15 @@ export class ShopService {
           hasCheckoutSettings: "checkoutSettings" in input,
         });
 
+        const sanitizedInput = stripLegacyDigitalShopSettings(input);
+
+        if (Object.keys(sanitizedInput).length === 0) {
+          logger.debug("No supported shop settings to update");
+          return null;
+        }
+
         // TODO: check diff between current and new settings to avoid unnecessary updates
-        const result = await this.repository.updateShopSettings(input);
+        const result = await this.repository.updateShopSettings(sanitizedInput);
 
         logger.debug("Successfully updated shop settings");
         return result;

--- a/src/test-helpers/graphql-mocks.ts
+++ b/src/test-helpers/graphql-mocks.ts
@@ -377,8 +377,6 @@ export function createFetchMock() {
               trackInventoryByDefault: true,
               reserveStockDurationAnonymousUser: 10,
               reserveStockDurationAuthenticatedUser: 10,
-              defaultDigitalMaxDownloads: null,
-              defaultDigitalUrlValidDays: null,
               defaultWeightUnit: "KG",
               allowLoginWithoutConfirmation: false,
             },


### PR DESCRIPTION
## Summary
- Stop querying Saleor 3.23 removed digital shop fields.
- Keep legacy digital shop settings valid in config files, but ignore them during deploy.
- Add the final 1.x patch changeset.

## Validation
- pnpm test src/modules/config/repository.test.ts src/modules/shop/shop-service.test.ts src/modules/config/schema/schema.test.ts src/commands/deploy.integration.test.ts
- pnpm test src/commands/introspect.test.ts src/commands/diff.test.ts src/core/diff/service.test.ts
- pnpm typecheck
- pnpm check:ci