### PR TITLE
Fix include/exclude section scoping

### DIFF
--- a/.changeset/scoped-include-exclude.md
+++ b/.changeset/scoped-include-exclude.md
@@ -1,0 +1,7 @@
+---
+"@saleor/configurator": patch
+---
+
+Make `--include` and `--exclude` consistently scope diff and deploy processing by top-level config section.
+
+The flags now apply to `diff`, `deploy`, and `introspect` without changing the GraphQL introspection query. Excluded sections are not parsed, compared, or processed independently, and commands reject using include and exclude together.

--- a/src/commands/deploy.test.ts
+++ b/src/commands/deploy.test.ts
@@ -337,6 +337,40 @@ describe("Deploy Command", () => {
       expect(mockExit).toHaveBeenCalledWith(0);
     });
 
+    it("should pass scoped include options to diff and deployment context", async () => {
+      const diff = vi.fn().mockResolvedValue({
+        summary: {
+          totalChanges: 1,
+          creates: 1,
+          updates: 0,
+          deletes: 0,
+          results: [{ operation: "CREATE", entityType: "Products", entityName: "phone" }],
+        },
+        output: "",
+      });
+      const configurator = createMockConfigurator(mockDiffService, { diff });
+      configurator.services.configStorage.load = vi.fn().mockResolvedValue({
+        shop: { defaultMailSenderName: "Test" },
+        categories: [{ name: "Electronics", slug: "electronics" }],
+        products: [],
+      });
+      mockCreateConfigurator.mockReturnValue(configurator);
+
+      await expect(deployHandler(createDefaultArgs({ include: "products" }))).rejects.toThrow(
+        "process.exit(0)"
+      );
+
+      expect(diff).toHaveBeenCalledWith({
+        skipMedia: false,
+        includeSections: ["products"],
+        excludeSections: [],
+      });
+      expect(mockExecuteEnhancedDeployment).toHaveBeenCalledOnce();
+      expect(mockExecuteEnhancedDeployment.mock.calls[0][1].config).toEqual({
+        products: [],
+      });
+    });
+
     it("should skip confirmation in CI mode", async () => {
       await expect(deployHandler(createDefaultArgs())).rejects.toThrow("process.exit(0)");
 

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -36,8 +36,14 @@ import { isNonInteractiveEnvironment } from "../lib/ci-mode";
 import { buildEnvelope, outputEnvelope } from "../lib/json-envelope";
 import { globalLogCollector } from "../lib/json-log-collector";
 import { logger } from "../lib/logger";
+import {
+  getSelectiveOptionsSummary,
+  parseSelectiveOptions,
+  scopeConfig,
+} from "../lib/utils/selective-options";
 import { COMMAND_NAME } from "../meta";
 import { AttributeCache } from "../modules/attribute/attribute-cache";
+import type { SaleorConfig } from "../modules/config/schema/schema";
 
 export const deployCommandSchema = baseCommandArgsSchema.extend({
   reportPath: z
@@ -54,6 +60,11 @@ export const deployCommandSchema = baseCommandArgsSchema.extend({
     .boolean()
     .default(false)
     .describe("Skip media fields during deployment (preserves target media)"),
+  include: z
+    .string()
+    .optional()
+    .describe("Comma-separated list of sections to include (e.g., 'channels,shop')"),
+  exclude: z.string().optional().describe("Comma-separated list of sections to exclude"),
   text: z.boolean().default(false).describe("Force human-readable output even in non-TTY mode"),
 });
 
@@ -235,7 +246,7 @@ class DeployCommandHandler implements CommandHandler<DeployCommandArgs, void> {
     summary: DiffSummary
   ): Promise<void> {
     try {
-      const cfg = await context.configurator.services.configStorage.load();
+      const cfg = context.config ?? (await context.configurator.services.configStorage.load());
       const suggestions = analyzeDeploymentCleanup(cfg, summary);
       if (suggestions.length > 0) {
         this.console.warn("🔎 Post-deploy cleanup suggestions:");
@@ -294,7 +305,8 @@ class DeployCommandHandler implements CommandHandler<DeployCommandArgs, void> {
   private async executeDeployment(
     args: DeployCommandArgs,
     summary: DiffSummary,
-    configurator: ReturnType<typeof createConfigurator>
+    configurator: ReturnType<typeof createConfigurator>,
+    config: SaleorConfig
   ): Promise<{ metrics: DeploymentMetrics; exitCode: number; hasPartialSuccess: boolean }> {
     const startTime = new Date();
 
@@ -307,6 +319,7 @@ class DeployCommandHandler implements CommandHandler<DeployCommandArgs, void> {
       summary,
       startTime,
       attributeCache: new AttributeCache(),
+      config,
     };
 
     const { metrics, result, exitCode } = await executeEnhancedDeployment(getAllStages(), context);
@@ -336,11 +349,14 @@ class DeployCommandHandler implements CommandHandler<DeployCommandArgs, void> {
 
   private async validateLocalConfiguration(
     args: DeployCommandArgs,
-    configurator: ReturnType<typeof createConfigurator>
-  ): Promise<void> {
+    configurator: ReturnType<typeof createConfigurator>,
+    selectiveOptions: ReturnType<typeof parseSelectiveOptions>
+  ): Promise<SaleorConfig> {
     try {
       const cfg = await configurator.services.configStorage.load();
-      runPreflightValidation(cfg, args.config);
+      const scopedConfig = scopeConfig(cfg, selectiveOptions);
+      runPreflightValidation(scopedConfig, args.config);
+      return scopedConfig;
     } catch (error) {
       if (error instanceof ConfigurationValidationError) {
         throw error;
@@ -354,7 +370,8 @@ class DeployCommandHandler implements CommandHandler<DeployCommandArgs, void> {
 
   private async analyzeDifferences(
     args: DeployCommandArgs,
-    configurator: ReturnType<typeof createConfigurator>
+    configurator: ReturnType<typeof createConfigurator>,
+    selectiveOptions: ReturnType<typeof parseSelectiveOptions>
   ): Promise<{
     summary: DiffSummary;
     output: string;
@@ -362,6 +379,8 @@ class DeployCommandHandler implements CommandHandler<DeployCommandArgs, void> {
   }> {
     const { summary, output } = await configurator.diff({
       skipMedia: args.skipMedia,
+      includeSections: selectiveOptions.includeSections,
+      excludeSections: selectiveOptions.excludeSections,
     });
 
     return {
@@ -400,7 +419,11 @@ class DeployCommandHandler implements CommandHandler<DeployCommandArgs, void> {
     };
   }
 
-  private checkDeletionPolicy(summary: DiffSummary, args: DeployCommandArgs, useJson: boolean): void {
+  private checkDeletionPolicy(
+    summary: DiffSummary,
+    args: DeployCommandArgs,
+    useJson: boolean
+  ): void {
     if (args.failOnDelete && summary.deletes > 0) {
       const message = `Deployment blocked: ${summary.deletes} deletion(s) detected (--fail-on-delete is enabled)`;
       if (useJson) {
@@ -475,13 +498,24 @@ class DeployCommandHandler implements CommandHandler<DeployCommandArgs, void> {
     const useJson = shouldOutputJson(args);
 
     try {
-      await this.validateLocalConfiguration(args, configurator);
+      const selectiveOptions = parseSelectiveOptions(args);
+      if (!useJson) {
+        const selectiveSummary = getSelectiveOptionsSummary(selectiveOptions);
+        [selectiveSummary.includeMessage, selectiveSummary.excludeMessage]
+          .filter((message): message is string => Boolean(message))
+          .forEach((message) => this.console.muted(message));
+      }
+      const scopedConfig = await this.validateLocalConfiguration(
+        args,
+        configurator,
+        selectiveOptions
+      );
 
       if (!useJson) {
         this.console.muted("⏳ Analyzing configuration differences...");
       }
 
-      const diffAnalysis = await this.analyzeDifferences(args, configurator);
+      const diffAnalysis = await this.analyzeDifferences(args, configurator, selectiveOptions);
 
       if (diffAnalysis.summary.totalChanges === 0) {
         return this.handleNoChanges(diffAnalysis.summary, useJson);
@@ -507,7 +541,12 @@ class DeployCommandHandler implements CommandHandler<DeployCommandArgs, void> {
         process.exit(0);
       }
 
-      const deploymentResult = await this.executeDeployment(args, diffAnalysis.summary, configurator);
+      const deploymentResult = await this.executeDeployment(
+        args,
+        diffAnalysis.summary,
+        configurator,
+        scopedConfig
+      );
       this.logDeploymentCompletion(diffAnalysis.summary, deploymentResult);
       process.exit(deploymentResult.exitCode);
     } catch (error) {

--- a/src/commands/diff.test.ts
+++ b/src/commands/diff.test.ts
@@ -177,6 +177,18 @@ describe("diff command", () => {
       expect(mockConfigurator.diff).toHaveBeenCalledOnce();
     });
 
+    it("should pass include and exclude options to configurator.diff()", async () => {
+      await expect(handleDiff({ ...mockArgs, include: "menus,products" })).rejects.toThrow(
+        "process.exit"
+      );
+
+      expect(mockConfigurator.diff).toHaveBeenCalledWith({
+        skipMedia: false,
+        includeSections: ["menus", "products"],
+        excludeSections: [],
+      });
+    });
+
     it("should display diff output", async () => {
       await expect(handleDiff(mockArgs)).rejects.toThrow("process.exit");
 
@@ -382,13 +394,9 @@ describe("diff command", () => {
         output: "Diff output",
       });
 
-      await expect(
-        handleDiff({ ...baseArgs, failOnDelete: true })
-      ).rejects.toThrow("process.exit");
+      await expect(handleDiff({ ...baseArgs, failOnDelete: true })).rejects.toThrow("process.exit");
 
-      expect(mockConsole.error).toHaveBeenCalledWith(
-        expect.stringContaining("--fail-on-delete")
-      );
+      expect(mockConsole.error).toHaveBeenCalledWith(expect.stringContaining("--fail-on-delete"));
       expect(process.exit).toHaveBeenCalledWith(EXIT_CODES.DELETION_BLOCKED);
     });
 
@@ -398,13 +406,11 @@ describe("diff command", () => {
         output: "Diff output",
       });
 
-      await expect(
-        handleDiff({ ...baseArgs, failOnBreaking: true })
-      ).rejects.toThrow("process.exit");
-
-      expect(mockConsole.error).toHaveBeenCalledWith(
-        expect.stringContaining("--fail-on-breaking")
+      await expect(handleDiff({ ...baseArgs, failOnBreaking: true })).rejects.toThrow(
+        "process.exit"
       );
+
+      expect(mockConsole.error).toHaveBeenCalledWith(expect.stringContaining("--fail-on-breaking"));
       expect(process.exit).toHaveBeenCalledWith(EXIT_CODES.BREAKING_BLOCKED);
     });
 
@@ -414,18 +420,14 @@ describe("diff command", () => {
         creates: 1,
         updates: 0,
         deletes: 0,
-        results: [
-          { operation: "CREATE", entityType: "Categories", entityName: "electronics" },
-        ],
+        results: [{ operation: "CREATE", entityType: "Categories", entityName: "electronics" }],
       };
       mockConfigurator.diff.mockResolvedValueOnce({
         summary: noDeletions,
         output: "Diff output",
       });
 
-      await expect(
-        handleDiff({ ...baseArgs, failOnDelete: true })
-      ).rejects.toThrow("process.exit");
+      await expect(handleDiff({ ...baseArgs, failOnDelete: true })).rejects.toThrow("process.exit");
 
       expect(process.exit).toHaveBeenCalledWith(0);
     });
@@ -452,14 +454,12 @@ describe("diff command", () => {
         output: "Full diff output",
       });
 
-      await expect(
-        handleDiff({ ...baseArgs, entityType: "Categories" })
-      ).rejects.toThrow("process.exit");
+      await expect(handleDiff({ ...baseArgs, entityType: "Categories" })).rejects.toThrow(
+        "process.exit"
+      );
 
       // Should show filtered count (2 Categories), not all 3
-      expect(mockConsole.status).toHaveBeenCalledWith(
-        expect.stringContaining("2 differences")
-      );
+      expect(mockConsole.status).toHaveBeenCalledWith(expect.stringContaining("2 differences"));
     });
 
     it("should filter results by --entity", async () => {
@@ -468,14 +468,12 @@ describe("diff command", () => {
         output: "Full diff output",
       });
 
-      await expect(
-        handleDiff({ ...baseArgs, entity: "Categories/electronics" })
-      ).rejects.toThrow("process.exit");
+      await expect(handleDiff({ ...baseArgs, entity: "Categories/electronics" })).rejects.toThrow(
+        "process.exit"
+      );
 
       // Should show filtered count (1 specific entity)
-      expect(mockConsole.status).toHaveBeenCalledWith(
-        expect.stringContaining("1 difference")
-      );
+      expect(mockConsole.status).toHaveBeenCalledWith(expect.stringContaining("1 difference"));
     });
 
     it("should show no differences when filter matches nothing", async () => {
@@ -484,9 +482,9 @@ describe("diff command", () => {
         output: "Full diff output",
       });
 
-      await expect(
-        handleDiff({ ...baseArgs, entityType: "Channels" })
-      ).rejects.toThrow("process.exit");
+      await expect(handleDiff({ ...baseArgs, entityType: "Channels" })).rejects.toThrow(
+        "process.exit"
+      );
 
       expect(mockConsole.status).toHaveBeenCalledWith(
         expect.stringContaining("No differences found")

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -15,6 +15,11 @@ import {
 import { scanForDuplicateIdentifiers } from "../core/validation/preflight";
 import { buildEnvelope, outputEnvelope } from "../lib/json-envelope";
 import { logger } from "../lib/logger";
+import {
+  getSelectiveOptionsSummary,
+  parseSelectiveOptions,
+  scopeConfig,
+} from "../lib/utils/selective-options";
 import { COMMAND_NAME } from "../meta";
 
 /**
@@ -47,6 +52,13 @@ export const diffCommandSchema = baseCommandArgsSchema.extend({
     .string()
     .optional()
     .describe("Filter results to a specific entity (e.g., Categories/electronics)"),
+  /** Include only selected top-level config sections */
+  include: z
+    .string()
+    .optional()
+    .describe("Comma-separated list of sections to include (e.g., 'channels,shop')"),
+  /** Exclude selected top-level config sections */
+  exclude: z.string().optional().describe("Comma-separated list of sections to exclude"),
 });
 
 export type DiffCommandArgs = z.infer<typeof diffCommandSchema>;
@@ -148,17 +160,22 @@ class DiffCommandHandler implements CommandHandler<DiffCommandArgs, void> {
     const configurator = createConfigurator(args);
 
     try {
+      const selectiveOptions = parseSelectiveOptions(args);
       // Skip header for JSON/GitHub output (machine-readable)
       if (!useJson && !args.githubComment) {
         this.console.muted(
           "⏳ Preparing a diff between the configuration and the Saleor instance..."
         );
+        const selectiveSummary = getSelectiveOptionsSummary(selectiveOptions);
+        [selectiveSummary.includeMessage, selectiveSummary.excludeMessage]
+          .filter((message): message is string => Boolean(message))
+          .forEach((message) => this.console.muted(message));
       }
 
       // Preflight: surface duplicate identifiers with friendly output and block diff
       try {
         const cfg = await configurator.services.configStorage.load();
-        const dupes = scanForDuplicateIdentifiers(cfg);
+        const dupes = scanForDuplicateIdentifiers(scopeConfig(cfg, selectiveOptions));
         if (dupes.length > 0) {
           if (useJson) {
             outputEnvelope(
@@ -187,6 +204,7 @@ class DiffCommandHandler implements CommandHandler<DiffCommandArgs, void> {
 
       const { summary: rawSummary, output: defaultOutput } = await configurator.diff({
         skipMedia: args.skipMedia,
+        ...selectiveOptions,
       });
 
       // Apply entity filter if flags present

--- a/src/commands/selective-include-exclude-flags.test.ts
+++ b/src/commands/selective-include-exclude-flags.test.ts
@@ -21,13 +21,13 @@ describe("Bug #9: Selective Include/Exclude Flags Ignored", () => {
       expect(result.excludeSections).toEqual(["productTypes", "pageTypes"]);
     });
 
-    it("should handle both include and exclude (include takes precedence)", () => {
-      const result = parseSelectiveOptions({
-        include: "shop",
-        exclude: "channels",
-      });
-      expect(result.includeSections).toEqual(["shop"]);
-      expect(result.excludeSections).toEqual(["channels"]);
+    it("should reject both include and exclude", () => {
+      expect(() =>
+        parseSelectiveOptions({
+          include: "shop",
+          exclude: "channels",
+        })
+      ).toThrow("Cannot specify both --include/--only and --exclude");
     });
 
     it("should handle empty options", () => {

--- a/src/core/deployment/stages.ts
+++ b/src/core/deployment/stages.ts
@@ -29,17 +29,22 @@ import type {
 import type {
   ChannelInput,
   ChannelUpdateInput,
+  SaleorConfig,
   TaxConfigurationInput,
 } from "../../modules/config/schema/schema";
 import { StageAggregateError } from "./errors";
 
 import type { DeploymentContext, DeploymentStage } from "./types";
 
+async function getDeploymentConfig(context: DeploymentContext): Promise<SaleorConfig> {
+  return context.config ?? (await context.configurator.services.configStorage.load());
+}
+
 export const validationStage: DeploymentStage = {
   name: StageNames.VALIDATION,
   async execute(context) {
     try {
-      await context.configurator.services.configStorage.load();
+      await getDeploymentConfig(context);
     } catch (error) {
       throw new Error(
         `Configuration validation failed: ${error instanceof Error ? error.message : String(error)}`
@@ -52,7 +57,7 @@ export const shopSettingsStage: DeploymentStage = {
   name: StageNames.SHOP_SETTINGS,
   async execute(context) {
     try {
-      const config = await context.configurator.services.configStorage.load();
+      const config = await getDeploymentConfig(context);
       if (!config.shop) {
         logger.debug("No shop settings to update");
         return;
@@ -77,7 +82,7 @@ export const productTypesStage: DeploymentStage = {
   name: StageNames.PRODUCT_TYPES,
   async execute(context) {
     try {
-      const config = await context.configurator.services.configStorage.load();
+      const config = await getDeploymentConfig(context);
       if (!config.productTypes?.length) {
         logger.debug("No product types to manage");
         return;
@@ -411,7 +416,7 @@ export const attributesStage: DeploymentStage = {
   name: StageNames.ATTRIBUTES,
   async execute(context) {
     try {
-      const config = await context.configurator.services.configStorage.load();
+      const config = await getDeploymentConfig(context);
       const productAttributes = config.productAttributes ?? [];
       const contentAttributes = config.contentAttributes ?? [];
 
@@ -519,7 +524,7 @@ export const channelsStage: DeploymentStage = {
   name: StageNames.CHANNELS,
   async execute(context) {
     try {
-      const config = await context.configurator.services.configStorage.load();
+      const config = await getDeploymentConfig(context);
       if (!config.channels?.length) {
         logger.debug("No channels to manage");
         return;
@@ -603,7 +608,7 @@ export const pageTypesStage: DeploymentStage = {
   name: StageNames.PAGE_TYPES,
   async execute(context) {
     try {
-      const config = await context.configurator.services.configStorage.load();
+      const config = await getDeploymentConfig(context);
       if (!config.pageTypes?.length) {
         logger.debug("No page types to manage");
         return;
@@ -636,7 +641,7 @@ export const modelTypesStage: DeploymentStage = {
   name: StageNames.MODEL_TYPES,
   async execute(context) {
     try {
-      const config = await context.configurator.services.configStorage.load();
+      const config = await getDeploymentConfig(context);
       if (!config.modelTypes?.length) {
         logger.debug("No model types to manage");
         return;
@@ -671,7 +676,7 @@ export const collectionsStage: DeploymentStage = {
   name: StageNames.COLLECTIONS,
   async execute(context) {
     try {
-      const config = await context.configurator.services.configStorage.load();
+      const config = await getDeploymentConfig(context);
       if (!config.collections?.length) {
         logger.debug("No collections to manage");
         return;
@@ -696,7 +701,7 @@ export const menusStage: DeploymentStage = {
   name: StageNames.MENUS,
   async execute(context) {
     try {
-      const config = await context.configurator.services.configStorage.load();
+      const config = await getDeploymentConfig(context);
       if (!config.menus?.length) {
         logger.debug("No menus to manage");
         return;
@@ -723,7 +728,7 @@ export const modelsStage: DeploymentStage = {
     try {
       context.configurator.services.model.setAttributeCache(context.attributeCache);
 
-      const config = await context.configurator.services.configStorage.load();
+      const config = await getDeploymentConfig(context);
       if (!config.models?.length) {
         logger.debug("No models to manage");
         return;
@@ -763,7 +768,7 @@ export const categoriesStage: DeploymentStage = {
   name: StageNames.CATEGORIES,
   async execute(context) {
     try {
-      const config = await context.configurator.services.configStorage.load();
+      const config = await getDeploymentConfig(context);
       if (!config.categories?.length) {
         logger.debug("No categories to manage");
         return;
@@ -812,7 +817,7 @@ export const warehousesStage: DeploymentStage = {
   name: StageNames.WAREHOUSES,
   async execute(context) {
     try {
-      const config = await context.configurator.services.configStorage.load();
+      const config = await getDeploymentConfig(context);
       if (!config.warehouses?.length) {
         logger.debug("No warehouses to manage");
         return;
@@ -837,7 +842,7 @@ export const taxClassesStage: DeploymentStage = {
   name: StageNames.TAX_CLASSES,
   async execute(context) {
     try {
-      const config = await context.configurator.services.configStorage.load();
+      const config = await getDeploymentConfig(context);
       if (!config.taxClasses?.length) {
         logger.debug("No tax classes to manage");
         return;
@@ -862,7 +867,7 @@ export const shippingZonesStage: DeploymentStage = {
   name: StageNames.SHIPPING_ZONES,
   async execute(context) {
     try {
-      const config = await context.configurator.services.configStorage.load();
+      const config = await getDeploymentConfig(context);
       if (!config.shippingZones?.length) {
         logger.debug("No shipping zones to manage");
         return;
@@ -895,7 +900,7 @@ export const attributeChoicesPreflightStage: DeploymentStage = {
   name: StageNames.ATTRIBUTE_CHOICES_PREFLIGHT,
   async execute(context) {
     try {
-      const config = await context.configurator.services.configStorage.load();
+      const config = await getDeploymentConfig(context);
       if (!config.products || config.products.length === 0) return;
 
       const productChanges = context.summary.results.filter((r) => r.entityType === "Products");
@@ -1006,7 +1011,7 @@ export const productsStage: DeploymentStage = {
     try {
       context.configurator.services.product.setAttributeCache(context.attributeCache);
 
-      const config = await context.configurator.services.configStorage.load();
+      const config = await getDeploymentConfig(context);
       if (!config.products?.length) {
         logger.debug("No products to manage");
         return;

--- a/src/core/deployment/types.ts
+++ b/src/core/deployment/types.ts
@@ -1,5 +1,6 @@
 import type { DeployCommandArgs } from "../../commands/deploy";
 import type { AttributeCache } from "../../modules/attribute/attribute-cache";
+import type { SaleorConfig } from "../../modules/config/schema/schema";
 import type { SaleorConfigurator } from "../configurator";
 import type { DiffSummary } from "../diff";
 
@@ -9,6 +10,7 @@ export interface DeploymentContext {
   readonly summary: DiffSummary;
   readonly startTime: Date;
   readonly attributeCache: AttributeCache;
+  readonly config?: SaleorConfig;
   // Note: skipMedia is accessed via args.skipMedia to avoid duplication
 }
 

--- a/src/core/diff/service.ts
+++ b/src/core/diff/service.ts
@@ -1,7 +1,7 @@
 import yaml from "yaml";
 import { cliConsole } from "../../cli/console";
 import { logger } from "../../lib/logger";
-import { shouldIncludeSection } from "../../lib/utils/selective-options";
+import { scopeConfig, shouldIncludeSection } from "../../lib/utils/selective-options";
 import type { SaleorConfig } from "../../modules/config/schema/schema";
 import { ConfigurationLoadError, RemoteConfigurationError } from "../errors/configuration-errors";
 import type { ServiceContainer } from "../service-container";
@@ -80,14 +80,21 @@ export class DiffService {
    */
   async compare(options?: DiffOptions): Promise<DiffSummary> {
     const startTime = Date.now();
-    logger.info("Starting diff comparison", { skipMedia: options?.skipMedia });
+    const selectiveOptions = this.toSelectiveOptions(options);
+    logger.info("Starting diff comparison", {
+      skipMedia: options?.skipMedia,
+      includeSections: selectiveOptions.includeSections,
+      excludeSections: selectiveOptions.excludeSections,
+    });
 
     try {
       // Load configurations concurrently for better performance
-      const [localConfig, remoteConfig] = await Promise.all([
+      const [loadedLocalConfig, loadedRemoteConfig] = await Promise.all([
         this.loadLocalConfiguration(),
-        this.loadRemoteConfiguration(),
+        this.loadRemoteConfiguration(selectiveOptions),
       ]);
+      const localConfig = scopeConfig(loadedLocalConfig, selectiveOptions);
+      const remoteConfig = scopeConfig(loadedRemoteConfig, selectiveOptions);
 
       if (this.config.enableDebugLogging) {
         logger.debug("Configurations loaded", {
@@ -97,7 +104,10 @@ export class DiffService {
       }
 
       // Perform comparisons with options
-      const results = await this.performComparisons(localConfig, remoteConfig, options);
+      const results = await this.performSelectiveComparisons(localConfig, remoteConfig, {
+        ...selectiveOptions,
+        diffOptions: options,
+      });
 
       // Calculate summary statistics
       const summary = this.calculateSummary(results);
@@ -144,16 +154,17 @@ export class DiffService {
    * @throws {DiffComparisonError} When comparison fails
    */
   async compareForIntrospect(options: DiffServiceIntrospectOptions = {}): Promise<DiffSummary> {
-    const { includeSections, excludeSections } = options;
+    const selectiveOptions = this.toSelectiveOptions(options);
     const startTime = Date.now();
     logger.info("Starting diff comparison for introspect");
 
     try {
       // Load configurations concurrently for better performance
-      const [localConfig, remoteConfig] = await Promise.all([
+      const [loadedLocalConfig, remoteConfig] = await Promise.all([
         this.loadLocalConfigurationTolerant(),
-        this.loadRemoteConfiguration(),
+        this.loadRemoteConfiguration(selectiveOptions),
       ]);
+      const localConfig = scopeConfig(loadedLocalConfig, selectiveOptions);
 
       if (this.config.enableDebugLogging) {
         logger.debug("Configurations loaded for introspect", {
@@ -165,8 +176,8 @@ export class DiffService {
       // Perform comparisons with swapped order (remote as source, local as target)
       // This shows what will be removed/added/updated in the local file
       const results = await this.performSelectiveComparisons(remoteConfig, localConfig, {
-        includeSections,
-        excludeSections,
+        includeSections: selectiveOptions.includeSections,
+        excludeSections: selectiveOptions.excludeSections,
       });
 
       // Calculate summary statistics
@@ -334,7 +345,9 @@ export class DiffService {
   /**
    * Loads remote configuration with error handling and timeout
    */
-  private async loadRemoteConfiguration(): Promise<SaleorConfig> {
+  private async loadRemoteConfiguration(
+    selectiveOptions?: DiffServiceIntrospectOptions
+  ): Promise<SaleorConfig> {
     let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
     try {
       const timeoutPromise = new Promise<never>((_, reject) => {
@@ -347,7 +360,9 @@ export class DiffService {
         }, this.config.remoteTimeoutMs);
       });
 
-      const configPromise = this.services.configuration.retrieveWithoutSaving();
+      const configPromise = this.services.configuration.retrieveWithoutSaving(
+        selectiveOptions ? this.toSelectiveOptions(selectiveOptions) : undefined
+      );
       const config = await Promise.race([configPromise, timeoutPromise]);
 
       return config || {};
@@ -421,7 +436,7 @@ export class DiffService {
   private async performSelectiveComparisons(
     localConfig: SaleorConfig,
     remoteConfig: SaleorConfig,
-    options: DiffServiceIntrospectOptions
+    options: DiffServiceIntrospectOptions & { diffOptions?: DiffOptions }
   ): Promise<readonly DiffResult[]> {
     const { includeSections, excludeSections } = options;
     const comparisons: Promise<readonly DiffResult[]>[] = [];
@@ -436,7 +451,9 @@ export class DiffService {
 
     // Shop settings comparison
     if (shouldInclude("shop") && this.comparators.has("shop")) {
-      comparisons.push(this.performComparison("shop", localConfig.shop, remoteConfig.shop));
+      comparisons.push(
+        this.performComparison("shop", localConfig.shop, remoteConfig.shop, options.diffOptions)
+      );
     }
 
     // Entity array comparisons
@@ -463,7 +480,8 @@ export class DiffService {
           this.performComparison(
             entityType,
             localConfig[entityType as keyof SaleorConfig] || [],
-            remoteConfig[entityType as keyof SaleorConfig] || []
+            remoteConfig[entityType as keyof SaleorConfig] || [],
+            options.diffOptions
           )
         );
       }
@@ -472,6 +490,15 @@ export class DiffService {
     // Execute comparisons with concurrency limit
     const results = await this.executeConcurrently(comparisons);
     return results.flat();
+  }
+
+  private toSelectiveOptions(
+    options?: Pick<DiffOptions, "includeSections" | "excludeSections">
+  ): Required<Pick<DiffOptions, "includeSections" | "excludeSections">> {
+    return {
+      includeSections: options?.includeSections ?? [],
+      excludeSections: options?.excludeSections ?? [],
+    };
   }
 
   /**

--- a/src/core/diff/types.ts
+++ b/src/core/diff/types.ts
@@ -90,6 +90,10 @@ export interface DiffOptions {
    * Media differences will not be reported in diff results.
    */
   readonly skipMedia?: boolean;
+  /** Sections to include (empty array means include all) */
+  readonly includeSections?: readonly ConfigurationSection[];
+  /** Sections to exclude */
+  readonly excludeSections?: readonly ConfigurationSection[];
 }
 
 /**

--- a/src/lib/utils/selective-options.test.ts
+++ b/src/lib/utils/selective-options.test.ts
@@ -85,6 +85,24 @@ describe("selective-options utility", () => {
         `Invalid sections specified in --exclude: invalid, unknown. Available sections: ${AVAILABLE_SECTIONS.join(", ")}`
       );
     });
+
+    it("should reject include and exclude together", () => {
+      expect(() => parseSelectiveOptions({ include: "shop", exclude: "channels" })).toThrow(
+        "Cannot specify both --include/--only and --exclude"
+      );
+    });
+
+    it("should reject only and exclude together", () => {
+      expect(() => parseSelectiveOptions({ only: "shop", exclude: "channels" })).toThrow(
+        "Cannot specify both --include/--only and --exclude"
+      );
+    });
+
+    it("should reject include and only together", () => {
+      expect(() => parseSelectiveOptions({ include: "shop", only: "channels" })).toThrow(
+        "Cannot specify both --include and --only"
+      );
+    });
   });
 
   describe("shouldIncludeSection", () => {

--- a/src/lib/utils/selective-options.ts
+++ b/src/lib/utils/selective-options.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { ConfigurationSection, ParsedSelectiveOptions } from "../../core/diff/types";
+import type { SaleorConfig } from "../../modules/config/schema/schema";
 
 export type { ConfigurationSection } from "../../core/diff/types";
 
@@ -106,6 +107,18 @@ export const parseSelectiveOptions = (
   const only = "only" in validatedOptions ? validatedOptions.only : undefined;
   const include = "include" in validatedOptions ? validatedOptions.include : undefined;
   const exclude = validatedOptions.exclude;
+  const hasInclude = Boolean(include?.trim() || only?.trim());
+  const hasExclude = Boolean(exclude?.trim());
+
+  if (include?.trim() && only?.trim()) {
+    throw new Error("Invalid selective options: Cannot specify both --include and --only");
+  }
+
+  if (hasInclude && hasExclude) {
+    throw new Error(
+      "Invalid selective options: Cannot specify both --include/--only and --exclude"
+    );
+  }
 
   return {
     includeSections: parseIncludeSections(only, include),
@@ -135,6 +148,28 @@ export const shouldIncludeSection = (
   }
 
   return true;
+};
+
+export const hasSelectiveOptions = (options: ParsedSelectiveOptions): boolean =>
+  options.includeSections.length > 0 || options.excludeSections.length > 0;
+
+export const scopeConfig = (
+  config: SaleorConfig,
+  options: ParsedSelectiveOptions
+): SaleorConfig => {
+  if (!hasSelectiveOptions(options)) {
+    return config;
+  }
+
+  const scopedConfig: Partial<SaleorConfig> = {};
+
+  for (const section of AVAILABLE_SECTIONS) {
+    if (shouldIncludeSection(section, options) && config[section] !== undefined) {
+      scopedConfig[section] = config[section] as never;
+    }
+  }
+
+  return scopedConfig as SaleorConfig;
 };
 
 const createIncludeMessage = (

--- a/src/modules/config/config-service.ts
+++ b/src/modules/config/config-service.ts
@@ -75,12 +75,20 @@ export class ConfigurationService {
     const config = this.mapConfig(rawConfig, selectiveOptions);
     const options = selectiveOptions ?? { includeSections: [], excludeSections: [] };
 
-    const { productAttributes, contentAttributes } = this.mapGlobalAttributeSections(rawConfig);
-    if (shouldIncludeSection("productAttributes", options)) {
-      config.productAttributes = productAttributes;
-    }
-    if (shouldIncludeSection("contentAttributes", options)) {
-      config.contentAttributes = contentAttributes;
+    const includeProductAttributes = shouldIncludeSection("productAttributes", options);
+    const includeContentAttributes = shouldIncludeSection("contentAttributes", options);
+
+    if (includeProductAttributes || includeContentAttributes) {
+      const { productAttributes, contentAttributes } = this.mapGlobalAttributeSections(rawConfig, {
+        includeProductAttributes,
+        includeContentAttributes,
+      });
+      if (includeProductAttributes) {
+        config.productAttributes = productAttributes;
+      }
+      if (includeContentAttributes) {
+        config.contentAttributes = contentAttributes;
+      }
     }
     this.reorderConfigKeys(config as SaleorConfig);
 
@@ -306,7 +314,13 @@ export class ConfigurationService {
     });
   }
 
-  private mapGlobalAttributeSections(raw: RawSaleorConfig): {
+  private mapGlobalAttributeSections(
+    raw: RawSaleorConfig,
+    options: {
+      includeProductAttributes: boolean;
+      includeContentAttributes: boolean;
+    }
+  ): {
     productAttributes: ProductAttribute[];
     contentAttributes: ContentAttribute[];
   } {
@@ -333,6 +347,13 @@ export class ConfigurationService {
         );
       }
       const type: SaleorAttributeType = isSaleorAttributeType(rawType) ? rawType : "PRODUCT_TYPE";
+
+      if (type === "PRODUCT_TYPE" && !options.includeProductAttributes) {
+        continue;
+      }
+      if (type === "PAGE_TYPE" && !options.includeContentAttributes) {
+        continue;
+      }
 
       try {
         const fullAttr = this.mapAttribute(toRawAttribute(node), type);


### PR DESCRIPTION
## Summary
- add include/exclude support to diff and deploy, matching introspect section scoping
- reject include and exclude used together
- scope local/remote config before diffing and pass the scoped config into deploy stages
- avoid mapping excluded global attribute sections during introspection
- add a patch changeset

## How to test
Use a config with at least two top-level sections so the scoped behavior is visible, for example:

```yaml
shop:
  defaultMailSenderName: Scoped Test Shop

menus:
  - name: Main menu
    slug: main-menu
    items: []

categories:
  - name: Electronics
    slug: electronics
```

Then run the scoped commands against a test Saleor instance:

```bash
# Only menu differences should be shown; shop/categories should be ignored by the operation scope.
pnpm dev diff --include=menus --text

# The deployment plan should only include menu operations.
pnpm dev deploy --plan --include=menus --text

# The local output should omit menus while keeping other introspected sections.
pnpm dev introspect --exclude=menus --text

# Include and exclude are mutually exclusive and should fail fast.
pnpm dev diff --include=menus --exclude=shop --text
```

Expected behavior:
- `--include=menus` scopes comparison/deploy processing to the `menus` top-level config key.
- `--exclude=menus` keeps the GraphQL introspection query broad, but does not parse/save/process the `menus` section.
- Passing both include and exclude returns an argument error before diff/deploy work starts.

## Tests
- pnpm exec tsc --noEmit
- pnpm exec vitest run

Refs #171