### PR TITLE
fix: allow the same attribute name in product and content sections

### DIFF
--- a/.changeset/brave-donkeys-repeat.md
+++ b/.changeset/brave-donkeys-repeat.md
@@ -2,7 +2,7 @@
 "@saleor/configurator": patch
 ---
 
-Fixed `deploy` rejecting a configuration that `introspect` had just produced.
+Fixed `deploy` rejecting or failing to create a configuration where a product attribute and a content attribute share the same name.
 
 Saleor enforces attribute uniqueness on slug, not name, so a store can legitimately hold a `PRODUCT_TYPE` and a `PAGE_TYPE` attribute with the same name — for example two attributes both called "Related Products". Introspect writes each into its own section, but preflight validation then refused any name appearing in both `productAttributes` and `contentAttributes`, so deploying an unmodified introspected config failed with:
 
@@ -10,4 +10,4 @@ Saleor enforces attribute uniqueness on slug, not name, so a store can legitimat
 Attribute names must be unique across productAttributes and contentAttributes
 ```
 
-That rule has been removed. It was stricter than the deployment path requires: attribute resolution is scoped by type at every step — the attribute cache keeps a separate bucket per section, and attribute lookups filter on `type` — so a name shared across sections is never ambiguous. Duplicate names *within* a single section are still rejected.
+That rule has been removed. Attribute resolution is scoped by type, so a name shared across sections is not ambiguous. Configurator also no longer sends a name-derived slug when creating attributes. Saleor generates the globally unique slug instead, which prevents two new attributes with the same name from colliding. Duplicate names *within* a single section are still rejected.

--- a/.changeset/brave-donkeys-repeat.md
+++ b/.changeset/brave-donkeys-repeat.md
@@ -1,0 +1,13 @@
+---
+"@saleor/configurator": patch
+---
+
+Fixed `deploy` rejecting a configuration that `introspect` had just produced.
+
+Saleor enforces attribute uniqueness on slug, not name, so a store can legitimately hold a `PRODUCT_TYPE` and a `PAGE_TYPE` attribute with the same name — for example two attributes both called "Related Products". Introspect writes each into its own section, but preflight validation then refused any name appearing in both `productAttributes` and `contentAttributes`, so deploying an unmodified introspected config failed with:
+
+```
+Attribute names must be unique across productAttributes and contentAttributes
+```
+
+That rule has been removed. It was stricter than the deployment path requires: attribute resolution is scoped by type at every step — the attribute cache keeps a separate bucket per section, and attribute lookups filter on `type` — so a name shared across sections is never ambiguous. Duplicate names *within* a single section are still rejected.

--- a/src/core/validation/preflight.test.ts
+++ b/src/core/validation/preflight.test.ts
@@ -5,7 +5,6 @@ import {
   runPreflightValidation,
   scanForDuplicateIdentifiers,
   validateAttributeReferences,
-  validateNoCrossSectionDuplicates,
   validateNoDuplicateIdentifiers,
   validateSingleDefaultCustomerType,
 } from "./preflight";
@@ -47,30 +46,37 @@ describe("Duplicate preflight validation", () => {
   });
 });
 
-describe("validateNoCrossSectionDuplicates", () => {
-  it("throws when attribute name appears in both sections", () => {
-    const cfg = {
-      productAttributes: [{ name: "Color", inputType: "DROPDOWN" }],
-      contentAttributes: [{ name: "Color", inputType: "PLAIN_TEXT" }],
-    } as unknown as SaleorConfig;
+describe("attribute names shared across sections", () => {
+  // Saleor enforces uniqueness on slug, not name: a store can hold a
+  // PRODUCT_TYPE and a PAGE_TYPE attribute called "Related Products", and
+  // introspect emits both. Deploying that config must work.
+  const sharedNameConfig = {
+    productAttributes: [{ name: "Related Products", inputType: "DROPDOWN" }],
+    contentAttributes: [{ name: "Related Products", inputType: "PLAIN_TEXT" }],
+    productTypes: [{ name: "T-Shirt", productAttributes: [{ attribute: "Related Products" }] }],
+    modelTypes: [{ name: "Blog Post", attributes: [{ attribute: "Related Products" }] }],
+  } as unknown as SaleorConfig;
 
-    expect(() => validateNoCrossSectionDuplicates(cfg, "config.yml")).toThrow(
-      /unique across productAttributes and contentAttributes/
-    );
+  it("accepts the same attribute name in productAttributes and contentAttributes", () => {
+    expect(() => runPreflightValidation(sharedNameConfig, "config.yml")).not.toThrow();
   });
 
-  it("passes when no overlap between sections", () => {
-    const cfg = {
-      productAttributes: [{ name: "Color", inputType: "DROPDOWN" }],
-      contentAttributes: [{ name: "Author", inputType: "PLAIN_TEXT" }],
-    } as unknown as SaleorConfig;
-
-    expect(() => validateNoCrossSectionDuplicates(cfg, "config.yml")).not.toThrow();
+  it("resolves references per section rather than globally", () => {
+    expect(() => validateAttributeReferences(sharedNameConfig, "config.yml")).not.toThrow();
   });
 
-  it("passes when sections are empty", () => {
-    const cfg = {} as SaleorConfig;
-    expect(() => validateNoCrossSectionDuplicates(cfg, "config.yml")).not.toThrow();
+  it("still rejects a duplicate name within a single section", () => {
+    const cfg = {
+      productAttributes: [
+        { name: "Color", inputType: "DROPDOWN" },
+        { name: "Color", inputType: "PLAIN_TEXT" },
+      ],
+    } as unknown as SaleorConfig;
+
+    expect(scanForDuplicateIdentifiers(cfg)).toEqual([
+      expect.objectContaining({ section: "productAttributes", identifier: "Color" }),
+    ]);
+    expect(() => runPreflightValidation(cfg, "config.yml")).toThrow(ConfigurationValidationError);
   });
 });
 
@@ -252,12 +258,14 @@ describe("runPreflightValidation", () => {
 
   it("throws single error directly when only one validation fails", () => {
     const cfg = {
-      productAttributes: [{ name: "Color", inputType: "DROPDOWN" }],
-      contentAttributes: [{ name: "Color", inputType: "PLAIN_TEXT" }],
+      productAttributes: [
+        { name: "Color", inputType: "DROPDOWN" },
+        { name: "Color", inputType: "PLAIN_TEXT" },
+      ],
     } as unknown as SaleorConfig;
 
     expect(() => runPreflightValidation(cfg, "config.yml")).toThrow(
-      /unique across productAttributes and contentAttributes/
+      /Duplicate entity identifiers found/
     );
   });
 

--- a/src/core/validation/preflight.ts
+++ b/src/core/validation/preflight.ts
@@ -161,23 +161,12 @@ export function validateNoInlineAttributeDefinitions(config: SaleorConfig, fileP
   );
 }
 
-export function validateNoCrossSectionDuplicates(config: SaleorConfig, filePath: string): void {
-  const productNames = new Set((config.productAttributes ?? []).map((a) => a.name));
-  const crossDupes = (config.contentAttributes ?? [])
-    .filter((a) => productNames.has(a.name))
-    .map((a) => a.name);
-
-  if (crossDupes.length > 0) {
-    throw new ConfigurationValidationError(
-      "Attribute names must be unique across productAttributes and contentAttributes",
-      filePath,
-      crossDupes.map((name) => ({
-        path: "productAttributes/contentAttributes",
-        message: `"${name}" appears in both productAttributes and contentAttributes. Each attribute must exist in only one section.`,
-      }))
-    );
-  }
-}
+// Note: an attribute name may appear in both productAttributes and
+// contentAttributes. Saleor enforces uniqueness on slug, not name, so a store
+// can legitimately hold a PRODUCT_TYPE and a PAGE_TYPE attribute with the same
+// name — and introspect emits both. Resolution stays unambiguous because every
+// lookup is scoped by attribute type: the attribute cache keeps one bucket per
+// section, and repository queries filter on `type`.
 
 /**
  * Saleor allows exactly one default customer type: setting `isDefault` on one
@@ -274,7 +263,6 @@ export function runPreflightValidation(config: SaleorConfig, filePath: string): 
   const validators = [
     validateNoDuplicateIdentifiers,
     validateSingleDefaultCustomerType,
-    validateNoCrossSectionDuplicates,
     validateNoInlineAttributeDefinitions,
     validateAttributeReferences,
   ];

--- a/src/core/validation/preflight.ts
+++ b/src/core/validation/preflight.ts
@@ -165,8 +165,8 @@ export function validateNoInlineAttributeDefinitions(config: SaleorConfig, fileP
 // contentAttributes. Saleor enforces uniqueness on slug, not name, so a store
 // can legitimately hold a PRODUCT_TYPE and a PAGE_TYPE attribute with the same
 // name — and introspect emits both. Resolution stays unambiguous because every
-// lookup is scoped by attribute type: the attribute cache keeps one bucket per
-// section, and repository queries filter on `type`.
+// lookup is scoped by attribute type. When creating attributes, Configurator
+// leaves the slug unset so Saleor can generate a globally unique value.
 
 /**
  * Saleor allows exactly one default customer type: setting `isDefault` on one

--- a/src/modules/attribute/attribute-service.test.ts
+++ b/src/modules/attribute/attribute-service.test.ts
@@ -76,7 +76,6 @@ describe("AttributeService", () => {
       expect(result).toEqual({
         name: "Featured Product",
         type: "PRODUCT_TYPE",
-        slug: "featured-product",
         inputType: "SINGLE_REFERENCE",
         entityType: "PRODUCT",
       });
@@ -107,7 +106,6 @@ describe("AttributeService", () => {
       expect(result).toEqual({
         name: "Related Page",
         type: "PAGE_TYPE",
-        slug: "related-page",
         inputType: "SINGLE_REFERENCE",
         entityType: "PAGE",
       });
@@ -126,7 +124,6 @@ describe("AttributeService", () => {
       expect(result).toEqual({
         name: "Related Category",
         type: "PRODUCT_TYPE",
-        slug: "related-category",
         inputType: "REFERENCE",
         entityType: "CATEGORY",
       });
@@ -145,10 +142,25 @@ describe("AttributeService", () => {
       expect(result).toEqual({
         name: "Featured Collection",
         type: "PRODUCT_TYPE",
-        slug: "featured-collection",
         inputType: "SINGLE_REFERENCE",
         entityType: "COLLECTION",
       });
+    });
+
+    it("lets Saleor generate unique slugs for attributes with the same name", () => {
+      const productAttribute: FullAttribute = {
+        name: "Related Products",
+        inputType: "PLAIN_TEXT",
+        type: "PRODUCT_TYPE",
+      };
+      const contentAttribute: FullAttribute = {
+        name: "Related Products",
+        inputType: "PLAIN_TEXT",
+        type: "PAGE_TYPE",
+      };
+
+      expect(createAttributeInput(productAttribute)).not.toHaveProperty("slug");
+      expect(createAttributeInput(contentAttribute)).not.toHaveProperty("slug");
     });
   });
 

--- a/src/modules/attribute/attribute-service.ts
+++ b/src/modules/attribute/attribute-service.ts
@@ -6,7 +6,6 @@ import {
   WrongAttributeTypeError,
 } from "../../lib/errors/validation-errors";
 import { logger } from "../../lib/logger";
-import { toSlug } from "../../lib/utils/string";
 import type { AttributeInput, FullAttribute } from "../config/schema/attribute.schema";
 import type { AttributeCache, AttributeSection, CachedAttribute } from "./attribute-cache";
 import { AttributeValidationError } from "./errors";
@@ -25,7 +24,6 @@ export const createAttributeInput = (input: FullAttribute): AttributeCreateInput
   const base = {
     name: input.name,
     type: input.type,
-    slug: toSlug(input.name),
     inputType: input.inputType,
   };
 

--- a/src/modules/product-type/product-type-service.test.ts
+++ b/src/modules/product-type/product-type-service.test.ts
@@ -124,7 +124,6 @@ describe("ProductTypeService", () => {
       expect(mockAttributeOperations.createAttribute).toHaveBeenCalledWith({
         name: "Color",
         type: "PRODUCT_TYPE",
-        slug: "color",
         inputType: "DROPDOWN",
         values: [{ name: "Red" }],
       });
@@ -423,7 +422,6 @@ describe("ProductTypeService", () => {
       expect(mockAttributeOperations.createAttribute).toHaveBeenCalledWith({
         name: "Author",
         type: "PRODUCT_TYPE",
-        slug: "author",
         inputType: "PLAIN_TEXT",
       });
       expect(mockProductTypeOperations.assignAttributesToProductType).toHaveBeenCalledWith({


### PR DESCRIPTION
Saleor enforces attribute uniqueness on slug, not name, so a store can hold a PRODUCT_TYPE and a PAGE_TYPE attribute with the same name. Introspect wrote each into its own section, but preflight validation rejected any name present in both productAttributes and contentAttributes — so deploying an unmodified introspected config failed.

The rule was stricter than the deployment path requires: attribute resolution is scoped by type at every step. The attribute cache keeps one bucket per section, and repository lookups filter on `type`, so a shared name is never ambiguous. Duplicate names within a single section are still rejected.

How to reproduce the problem? Point Configurator to `3.23` environment having example database in Saleor Cloud, `introspect` and `deploy`.

```
Configuration validation failed

Details:
  • file: config.yml
  • errorCount: 1
  • validationErrors: productAttributes/contentAttributes: "Related Products" appears in both productAttributes and contentAttributes. Each attribute must exist in only one section.
```
